### PR TITLE
Allow maps to have buldings

### DIFF
--- a/sourcemod/scripting/TF2JailRedux/jailhandler.sp
+++ b/sourcemod/scripting/TF2JailRedux/jailhandler.sp
@@ -920,7 +920,7 @@ public void ManageEntityCreated(int ent, const char[] classname)
 	if (StrEqual(classname, "func_breakable") && cvarTF2Jail[VentHit].BoolValue)
 		RequestFrame(HookVent, EntIndexToEntRef(ent));
 
-	if (StrContains(classname, "obj_", false) != -1)
+	if (StrEqual(classname, "obj_dispenser") || StrEqual(classname, "obj_sentrygun") || StrEqual(classname, "obj_teleporter"))
 		SDKHook(ent, SDKHook_Spawn, OnBuildingSpawn);
 }
 /**

--- a/sourcemod/scripting/TF2Jail_Redux.sp
+++ b/sourcemod/scripting/TF2Jail_Redux.sp
@@ -1338,7 +1338,7 @@ public Action OnEntSpawn(int ent)
 public Action OnBuildingSpawn(int ent)
 {
 	if (IsValidEntity(ent))
-		if (!gamemode.bAllowBuilding)
+		if (!gamemode.bAllowBuilding && GetEntPropEnt(ent, Prop_Send, "m_hBuilder") != -1)
 			RemoveEntity(ent);
 	return Plugin_Continue;
 }


### PR DESCRIPTION
We compare if the entity is called either of the 3 object names of the building, due to there being an object called "obj_attachment_sapper"